### PR TITLE
Fixed newline that caused syntax error

### DIFF
--- a/math.rock
+++ b/math.rock
@@ -7,7 +7,6 @@ Give back 1
 If the number is less than the zero
 Give back -1
 
-  
 Put 1 into the iterator
 Put 1 into the answer
 While the iterator is as little as the number


### PR DESCRIPTION
As title mentions, the python transpiler complained when one of your functions included a newline too many, and ended the function prematurely.