### PR TITLE
Add pi constant and tangent function

### DIFF
--- a/math.rock
+++ b/math.rock
@@ -149,6 +149,13 @@ Put the sign times -1 into the sign
 Give back the answer
 
 
+(Tan)
+Tan takes the radian
+Put Sine taking the radian into the numerator
+Put Cos taking the radian into the denominator
+Give back the numerator over the denominator
+
+
 (Get binary from decimal)
 DecToBin takes the number
 If the number is as little as 1

--- a/math.rock
+++ b/math.rock
@@ -1,3 +1,7 @@
+(Pi constant)
+Put 3.1415926535897932 into the pi
+
+
 (Factorial: n!)
 Factorial takes the number
 Put 0 into the zero

--- a/math.test.py
+++ b/math.test.py
@@ -1,5 +1,5 @@
-from rockmath import Factorial as rockfactorial, Power, LN as rockln, Square_Root as rocksqrt, Absolute_Value, the_e, the_pi, Mod, LOG as rocklog, Exp, Sine, Cos
-from math import factorial as pyfactorial, log as pyln, sqrt as pysqrt, sin, pi, cos
+from rockmath import Factorial as rockfactorial, Power, LN as rockln, Square_Root as rocksqrt, Absolute_Value, the_e, the_pi, Mod, LOG as rocklog, Exp, Sine, Cos, Tan
+from math import factorial as pyfactorial, log as pyln, sqrt as pysqrt, sin, pi, cos, tan
 import math
 
 def run_factorial_test():
@@ -75,6 +75,12 @@ def run_cos_test():
         x *= pi / 8
         assert_close( cos(x), Cos(x), "cos({})".format(x))
 
+def run_tan_test():
+    for x in range(-7, 7):
+        print("Doing tan({} * pi / 2)".format(x))
+        x *= pi / 16
+        assert_close( tan(x), Tan(x), "tan({})".format(x))
+
 def run_dec_to_bin_test():
     pass  # not using until we have integer division
 
@@ -90,6 +96,7 @@ def main():
     run_mod_test()
     run_sine_test()
     run_cos_test()
+    run_tan_test()
     run_dec_to_bin_test()
 
 if __name__ == '__main__':

--- a/math.test.py
+++ b/math.test.py
@@ -1,4 +1,4 @@
-from rockmath import Factorial as rockfactorial, Power, LN as rockln, Square_Root as rocksqrt, Absolute_Value, the_e, Mod, LOG as rocklog, Exp, Sine, Cos
+from rockmath import Factorial as rockfactorial, Power, LN as rockln, Square_Root as rocksqrt, Absolute_Value, the_e, the_pi, Mod, LOG as rocklog, Exp, Sine, Cos
 from math import factorial as pyfactorial, log as pyln, sqrt as pysqrt, sin, pi, cos
 import math
 
@@ -41,6 +41,10 @@ def run_abs_test():
 def run_e_test():
     assert_closer(math.e, the_e, "Approximation of e")
 
+def run_pi_test():
+    assert_close(pi, the_pi, "Approximation of pi")
+    assert_close(pi/2, the_pi/2, "Approximation of half pi")
+
 def run_log_test():
     for x in range(1, 10):
         for b in range(2, 5):
@@ -80,6 +84,7 @@ def main():
     run_ln_test()
     run_sqrt_test()
     run_abs_test()
+    run_pi_test()
     run_log_test()
     run_exponential_test()
     run_mod_test()

--- a/rockmath.py
+++ b/rockmath.py
@@ -113,6 +113,11 @@ def Cos(the_radian):
         the_iterator += 1
         the_sign = the_sign * -1
     return the_answer
+ #Tan
+def Tan(the_radian):
+    the_numerator = Sine(the_radian)
+    the_denominator = Cos(the_radian)
+    return the_numerator / the_denominator
  #Get binary from decimal
 def DecToBin(the_number):
     if the_number <= 1:

--- a/rockmath.py
+++ b/rockmath.py
@@ -1,3 +1,5 @@
+ #Pi constant
+the_pi = 3.1415926535897932
  #Factorial: n!
 def Factorial(the_number):
     the_zero = 0


### PR DESCRIPTION
This implementation of tangent "fails" when its argument is very close to pi/2.
By "fails" I mean that it outputs a very large number, as it should (since there is no Inf), but it's different from the python output.

It's not a huge issue, and I think it can still be used as is.