### PR TITLE
Improvements for logarithm and exponentiation

### DIFF
--- a/math.rock
+++ b/math.rock
@@ -100,16 +100,25 @@ Put the number minus 1 into the top
 Put the number plus 1 into the bottom
 Put the top over the bottom into the x
 Put 1 into the iterator 
-Put 0 into the sum
-While the iterator is less than 2000
+Put 0 into the approximation
+While the iterator is less than 10 (get reasonable starting point for Halley's method)
 Put Power taking the x, the iterator into the term
 Put the term over the iterator into the term
-Put the sum plus the term into the sum
+Put the approximation plus the term into the approximation
 Build the iterator up
 Build the iterator up
 
-Put the sum times 2 into the sum
-Give back the sum
+Put the approximation times 2 into the approximation (end power expansion, start Halley's cubic convergence)
+Put 0 into the iterator
+While the iterator is less than 30
+Put the number minus Exp taking the approximation into the numerator
+Put the number plus Exp taking the approximation into the denominator
+Put 2 times the numerator over the denominator into the term
+Put the approximation plus the term into the approximation
+Build the iterator up
+
+Give back the approximation
+
 
 (Log with number and base)
 LOG takes the number and the base

--- a/math.rock
+++ b/math.rock
@@ -23,18 +23,18 @@ Give back the answer
 (Abs value)
 Absolute Value takes The number
 If The number is less than 0
-Put The number times -1 into The number 
+Put The number times -1 into The number
 Give back The number
 
 Give back The number
 
 (Exp Estimate: estimate e^x, x close to 1)
 Exp Estimate takes The x and The Number Of Terms
-Put 0 into The Iterator 
+Put 0 into The Iterator
 Put 0 into The Answer
 While The Iterator is as little as The Number Of Terms
 Put Factorial taking The Iterator into the bottom
-Put The x over the bottom into The Term 
+Put The x over the bottom into The Term
 Put The Answer plus The Term into The Answer
 Build The Iterator up
 
@@ -43,7 +43,7 @@ Give back The Answer
 (Create variable: e)
 Put 1 into the x
 Put 50 into the terms
-Put Exp Estimate taking the x, the terms into the e 
+Put Exp Estimate taking the x, the terms into the e
 
 
 (Mod: a % m)
@@ -77,21 +77,55 @@ Give back the number
 
 
 (Power: a^x)
-Power takes the number and the exponent
+Power takes the base and the exponent
+If the exponent is less than 0
+Put -1 times the exponent into the newexponent
+Give back 1 over Power taking the base, the newexponent
+
+(If the base is 0 and  the exponent is 0)
+(Give back "Error: indefinite")
+()
 If the exponent is 0
 Give back 1
 
+If the base is 0
+Give back 0
+
+If Mod taking the exponent, 1 is 0
+Give back PowerIntegerExponent taking the base, the exponent
+Else
+Give back PowerRealExponent taking the base, the exponent
+
+
+(PowerIntegerExponent)
+PowerIntegerExponent takes the base and the exponent
 Put 1 into the iterator
-Put the number into the answer
-While the iterator is smaller than the exponent  (Probably can also use divide and conquer exponentiation -> e^n + e^m + ....)
-Put the number times the answer into the answer
+Put the base into the answer
+While the iterator is smaller than the exponent (Probably can also use divide and conquer exponentiation -> e^n + e^m + ....)
+Put the base times the answer into the answer
 Build the iterator up
 
 Give back the answer
 
 
+(PowerRealExponent)
+PowerRealExponent takes the base and the exponent
+Put the exponent times LN taking the base into the argument
+Give back Exp taking the argument
+
+
+(Exp)
 Exp takes the x
-Give back Power taking the e, the x 
+Put 1 into the answer
+Put 1 into the iterator
+While the iterator is less than 50
+Put Power taking the x, the iterator into the numerator
+Put Factorial taking the iterator into the denominator
+Put the numerator over the denominator into the term
+Put the answer plus the term into the answer
+Build the iterator up
+
+Give back the answer
 
 
 (Natural Logarithm, always base e)
@@ -99,7 +133,7 @@ LN takes the number
 Put the number minus 1 into the top
 Put the number plus 1 into the bottom
 Put the top over the bottom into the x
-Put 1 into the iterator 
+Put 1 into the iterator
 Put 0 into the approximation
 While the iterator is less than 10 (get reasonable starting point for Halley's method)
 Put Power taking the x, the iterator into the term

--- a/math.test.py
+++ b/math.test.py
@@ -18,8 +18,12 @@ def assert_close(x, y, m=""):
         assert False, "py({}) is not close to rock({})-{}".format(x,y,m)
 
 def run_power_test():
-    for x in range(10):
-        for n in range(10):
+    for x in range(-10, 10):
+        for n in [-10, -pi, -2.5, -2, -1, -0.15, 0, 0.15, 1, 2, 2.5, pi, 10]:
+            if x == 0 and n <= 0: # indefinite answer
+                continue
+            if x<0 and n%1!=0: # roots of negative numbers make complex numbers
+                continue
             print("testing {}**{}".format(x,n))
             assert_close(x**n, Power(x,n), "Failed for {}**{}".format(x,n))
 
@@ -62,7 +66,7 @@ def run_ceil_test():
         assert_close(ceil(x), Ceil(x), "Failed for ceil({})".format(x))
 
 def run_exponential_test():
-    for x in range(10):
+    for x in [-10, -1, -0.01, -0.00001, 0.0000001, 0.01, 1, pi, 10]:
         print("testing e ^ {}".format(x))
         assert_close( math.e ** x, Exp(x), "Failed for e ^ {}".format(x))
 

--- a/rockmath.py
+++ b/rockmath.py
@@ -71,15 +71,22 @@ def LN(the_number):
     the_bottom = the_number + 1
     the_x = the_top / the_bottom
     the_iterator = 1
-    the_sum = 0
-    while the_iterator < 2000:
+    the_approximation = 0
+    while the_iterator < 10: #get reasonable starting point for Halley's method
         the_term = Power(the_x, the_iterator)
         the_term = the_term / the_iterator
-        the_sum = the_sum + the_term
+        the_approximation = the_approximation + the_term
         the_iterator += 1
         the_iterator += 1
-    the_sum = the_sum * 2
-    return the_sum
+    the_approximation = the_approximation * 2 #end power expansion, start Halley's cubic convergence
+    the_iterator = 0
+    while the_iterator < 30:
+        the_numerator = the_number - Exp(the_approximation)
+        the_denominator = the_number + Exp(the_approximation)
+        the_term = 2 * the_numerator / the_denominator
+        the_approximation = the_approximation + the_term
+        the_iterator += 1
+    return the_approximation
  #Log with number and base
 def LOG(the_number, the_base):
     the_top = LN(the_number)

--- a/rockmath.py
+++ b/rockmath.py
@@ -54,17 +54,44 @@ def Ceil(the_number):
     the_number = -1 * Floor(the_number)
     return the_number
  #Power: a^x
-def Power(the_number, the_exponent):
+def Power(the_base, the_exponent):
+    if the_exponent < 0:
+        the_newexponent = -1 * the_exponent
+        return 1 / Power(the_base, the_newexponent)
+     #If the base is 0 and  the exponent is 0
+     #Give back "Error: indefinite"
+     #
     if the_exponent == 0:
         return 1
+    if the_base == 0:
+        return 0
+    if Mod(the_exponent, 1) == 0:
+        return PowerIntegerExponent(the_base, the_exponent)
+    else:
+        return PowerRealExponent(the_base, the_exponent)
+ #PowerIntegerExponent
+def PowerIntegerExponent(the_base, the_exponent):
     the_iterator = 1
-    the_answer = the_number
+    the_answer = the_base
     while the_iterator < the_exponent: #Probably can also use divide and conquer exponentiation -> e^n + e^m + ....
-        the_answer = the_number * the_answer
+        the_answer = the_base * the_answer
         the_iterator += 1
     return the_answer
+ #PowerRealExponent
+def PowerRealExponent(the_base, the_exponent):
+    the_argument = the_exponent * LN(the_base)
+    return Exp(the_argument)
+ #Exp
 def Exp(the_x):
-    return Power(the_e, the_x)
+    the_answer = 1
+    the_iterator = 1
+    while the_iterator < 50:
+        the_numerator = Power(the_x, the_iterator)
+        the_denominator = Factorial(the_iterator)
+        the_term = the_numerator / the_denominator
+        the_answer = the_answer + the_term
+        the_iterator += 1
+    return the_answer
  #Natural Logarithm, always base e
 def LN(the_number):
     the_top = the_number - 1


### PR DESCRIPTION
This is unfortunately a PR for two different things, but they are intertwined enough that I had to do it as a single thing.

First, the `LN` function is now faster. Instead of using 2000 iterations for power series convergence, I use the result from the first 10 terms as a starting point, and then switch to Halley's method for cubic convergence. See more here: [wiki link](https://en.wikipedia.org/wiki/Natural_logarithm#High_precision)

To do so, I had to rely on `Exp` with a non-integer exponent, so I fixed issue #7  too. There are now two sub-functions for the `Power` function, one with integer exponent, the other with real exponent.

When the exponent is not an integer, I use the `base^exponent = e^(exponent * ln( base))` identity.
When the exponent is integer (many Taylor series use it), I use the naive implementation of iterative multiplication.

All the tests pass, _I guess._ I'm not an expert in designing tests for math libraries, so I might have missed something.