### PR TITLE
Implement is_close(a,b) function

### DIFF
--- a/math.rock
+++ b/math.rock
@@ -40,6 +40,28 @@ Give back The number
 Give back The number
 
 
+(Is-close)
+Is Close takes the a and the b
+Put 0.000000001 into the relativetolerance (to be changed to an optional argument)
+Put 0 into the absolutetolerance (to be changed to an optional argument)
+Put Absolute Value taking the a into the largest
+If Absolute Value taking the b is greater than the largest
+Put Absolute Value taking the b into the largest
+
+Put the relativetolerance times the largest into the scalefactor
+If the absolutetolerance is greater than the scalefactor
+Put the absolutetolerance into the threshold
+Else
+Put the scalefactor into the threshold
+
+Put the a minus the b into the difference
+Put Absolute Value taking the difference into the difference
+If the difference is as little as the threshold
+Give back true
+Else
+Give back false
+
+
 (Mod: a % m)
 Mod takes the number and the modulo
 If the number is greater than 0

--- a/rockmath.py
+++ b/rockmath.py
@@ -27,6 +27,24 @@ def Absolute_Value(the_number):
         the_number = the_number * -1
         return the_number
     return the_number
+ #Is-close
+def Is_Close(the_a, the_b):
+    the_relativetolerance = 0.000000001 #to be changed to an optional argument
+    the_absolutetolerance = 0 #to be changed to an optional argument
+    the_largest = Absolute_Value(the_a)
+    if Absolute_Value(the_b) > the_largest:
+        the_largest = Absolute_Value(the_b)
+    the_scalefactor = the_relativetolerance * the_largest
+    if the_absolutetolerance > the_scalefactor:
+        the_threshold = the_absolutetolerance
+    else:
+        the_threshold = the_scalefactor
+    the_difference = the_a - the_b
+    the_difference = Absolute_Value(the_difference)
+    if the_difference <= the_threshold:
+        return True
+    else:
+        return False
  #Mod: a % m
 def Mod(the_number, the_modulo):
     if the_number > 0:


### PR DESCRIPTION
I've implemented the is_close(a,b) function as is specified in PEP 485:
https://www.python.org/dev/peps/pep-0485

At the moment there is no syntax for optional arguments, so the relative
tolerance and the absolute tolerance are hardcoded into the function code.
This will need to be changed whenever optional arguments are supported by the
language specification.